### PR TITLE
Time travel bug

### DIFF
--- a/src/pages/TimeTravel.js
+++ b/src/pages/TimeTravel.js
@@ -35,9 +35,10 @@ const TimeTravel = () => {
     .toISOString()
     .split("T")[0];
   const [selectedDate, setSelectedDate] = React.useState(yesterday);
+
   React.useEffect(() => {
-    const dayCount =
-      timeTravelDate >= 0 && timeTravelDate < getDayCount() ? timeTravelDate : getDayCount();
+    const dayCount = timeTravelDate >= 0 ? timeTravelDate : getDayCount();
+    console.log(timeTravelDate, "two");
     if (showLoader) {
       setLoading(true);
     }
@@ -60,16 +61,17 @@ const TimeTravel = () => {
 
   const handleChangeFromDate = (event) => {
     const selectedDate = event.target.value;
-    if (!selectedDate) {
+    let diff = getTimeDifference(
+      getDateTimeInUTC(new Date(selectedDate)),
+      new Date("2022-05-22T18:30:00.000Z")
+    );
+    if (!selectedDate || diff.days > getDayCount()) {
       setTimeTravelDate(getDayCount(new Date()) - 1);
       setSelectedDate(yesterday);
       return;
     }
     setSelectedDate(selectedDate);
-    let diff = getTimeDifference(
-      getDateTimeInUTC(new Date(selectedDate)),
-      new Date("2022-05-22T18:30:00.000Z")
-    );
+
     setTimeTravelDate(diff.days);
   };
 

--- a/src/pages/TimeTravel.js
+++ b/src/pages/TimeTravel.js
@@ -36,9 +36,9 @@ const TimeTravel = () => {
     .split("T")[0];
   const [selectedDate, setSelectedDate] = React.useState(yesterday);
 
+  console.log(getDayCount(), "two");
   React.useEffect(() => {
-    const dayCount = timeTravelDate >= 0 ? timeTravelDate : getDayCount();
-    console.log(timeTravelDate, "two");
+    const dayCount = timeTravelDate >= 0 ? timeTravelDate : getDayCount() - 1;
     if (showLoader) {
       setLoading(true);
     }

--- a/src/pages/TimeTravel.js
+++ b/src/pages/TimeTravel.js
@@ -65,7 +65,7 @@ const TimeTravel = () => {
       getDateTimeInUTC(new Date(selectedDate)),
       new Date("2022-05-22T18:30:00.000Z")
     );
-    if (!selectedDate || diff.days > getDayCount()) {
+    if (!selectedDate || diff.days > getDayCount() - 1) {
       setTimeTravelDate(getDayCount(new Date()) - 1);
       setSelectedDate(yesterday);
       return;


### PR DESCRIPTION
- Removed the ability to enter a future date than today (if you enter a future date with keyboard it doesn't take it past the date of the day before)
- time travel for anything not a date goes to yesterday's puzzle.

Sry for the multiple commits, I realised some things after the commit :D